### PR TITLE
Synchronize chart zoom with the page-wide date range

### DIFF
--- a/resources/js/Components/DatePicker.vue
+++ b/resources/js/Components/DatePicker.vue
@@ -31,21 +31,14 @@
 
 <script setup>
 import { ref, watch } from "vue";
-import { router } from "@inertiajs/vue3";
 import { DatePicker } from "v-calendar";
 import { CalendarIcon } from "vue-tabler-icons";
-
-const props = defineProps({
-  start: String,
-  end: String,
-});
+import { store } from "../store";
 
 const range = ref({
-  start: props.start,
-  end: props.end,
+  start: store.range.start,
+  end: store.range.end,
 });
 
-watch(range, (value) => {
-  router.get(`${location.pathname}?start=${value.start}&end=${value.end}`);
-});
+watch(range, (value) => store.range.update(value.start, value.end));
 </script>

--- a/resources/js/Components/TrendChart.vue
+++ b/resources/js/Components/TrendChart.vue
@@ -5,6 +5,7 @@
 <script setup>
 import { onMounted, ref, watch } from "vue";
 import ApexCharts from "apexcharts";
+import { store } from "../store";
 
 const props = defineProps(["title", "data"]);
 
@@ -18,6 +19,11 @@ const options = {
     height: 250,
     toolbar: {
       show: false,
+    },
+    events: {
+      zoomed: function (chartContext, { xaxis }) {
+        store.range.update(xaxis.min, xaxis.max);
+      },
     },
   },
   series: [

--- a/resources/js/Pages/Dashboards/Show.vue
+++ b/resources/js/Pages/Dashboards/Show.vue
@@ -4,7 +4,7 @@
   </Head>
 
   <Header>
-    <DatePicker :start="start" :end="end" />
+    <DatePicker />
   </Header>
 
   <div class="container mx-auto -mt-2 pb-32 lg:flex">
@@ -34,8 +34,10 @@ import Header from "../../Components/Header.vue";
 import Sidebar from "../../Components/Sidebar.vue";
 import DatePicker from "../../Components/DatePicker.vue";
 import Panels from "../../Components/Panels.vue";
+import { store } from "../../store";
 
-defineProps(["dashboard", "dashboards", "start", "end"]);
+const props = defineProps(["dashboard", "dashboards", "start", "end"]);
+store.range.update(props.start, props.end, false);
 
 const showSidebar = ref(false);
 </script>

--- a/resources/js/store.js
+++ b/resources/js/store.js
@@ -1,7 +1,19 @@
 import { reactive } from "vue";
-import { router, usePage } from "@inertiajs/vue3";
+import { router } from "@inertiajs/vue3";
 
 export const store = reactive({
+  range: {
+    start: null,
+    end: null,
+    update(start, end, refresh = true) {
+      this.start = start;
+      this.end = end;
+
+      if (refresh) {
+        router.get(`${location.pathname}?start=${this.start}&end=${this.end}`);
+      }
+    },
+  },
   dashboards: {
     create() {
       router.post(`/${usePage().props.path}/dashboards`);

--- a/src/Http/Controllers/DashboardsController.php
+++ b/src/Http/Controllers/DashboardsController.php
@@ -3,6 +3,7 @@
 namespace Chartello\Http\Controllers;
 
 use Chartello\Models\Dashboard;
+use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 
 class DashboardsController
@@ -54,13 +55,13 @@ class DashboardsController
     protected function resolveRenage()
     {
         $start = request('start', session('start'));
+        $start = is_numeric($start) ? Carbon::createFromTimestampMs($start) : $start;
+
         $end = request('end', session('end'));
+        $end = is_numeric($end) ? Carbon::createFromTimestampMs($end) : $end;
 
-        if (! $start) {
+        if (! $start || ! $end) {
             $start = now()->endOfDay()->subMonths(3)->format('Y-m-d');
-        }
-
-        if (! $end) {
             $end = now()->endOfDay()->format('Y-m-d');
         }
 


### PR DESCRIPTION
This PR integrates [ApexCharts' zoom functionality](https://apexcharts.com/docs/options/chart/zoom/) with the page-wide date range selection, so that zooming into a date range on one chart is automatically reflected across the page.

https://user-images.githubusercontent.com/10030505/219383985-1f266e34-4429-4ab5-b26b-f3579ffae11a.mov

