### PR TITLE
Make use of the url() helper and absolute paths to account for the url of the host app

### DIFF
--- a/resources/js/Components/Header.vue
+++ b/resources/js/Components/Header.vue
@@ -4,7 +4,7 @@
       class="container mx-auto flex flex-col items-end items-center justify-center px-6 pt-12 pb-12 md:flex-row"
     >
       <Link
-        :href="`/${$page.props.path}`"
+        :href="`${$page.props.path}`"
         class="mb-6 flex items-center justify-center text-xl text-white md:mr-auto md:mb-0"
       >
         <Logo />

--- a/resources/js/Components/NavLink.vue
+++ b/resources/js/Components/NavLink.vue
@@ -63,7 +63,11 @@ const props = defineProps(["dashboard"]);
 const editing = ref(false);
 
 const url = computed(() => {
-  return `/${usePage().props.path}/dashboards/${props.dashboard.id}`;
+  return `${usePage().props.path}/dashboards/${props.dashboard.id}`;
+});
+
+const pathname = computed(() => {
+  return new URL(url.value).pathname;
 });
 
 const active = computed(() => {
@@ -74,7 +78,7 @@ const active = computed(() => {
       ? current
       : current.substring(0, current.indexOf("?"));
 
-  return current === url.value;
+  return current === pathname.value;
 });
 
 const form = useForm({
@@ -116,6 +120,6 @@ onMounted(() => {
 });
 
 router.on("start", (event) => {
-  loading.value = event.detail.visit.url.pathname === url.value;
+  loading.value = event.detail.visit.url.pathname === pathname.value;
 });
 </script>

--- a/resources/js/Components/Panel.vue
+++ b/resources/js/Components/Panel.vue
@@ -172,14 +172,14 @@ function edit() {
 }
 
 function update() {
-  form.put(`/${usePage().props.path}/panels/${props.panel.id}`, {
+  form.put(`${usePage().props.path}/panels/${props.panel.id}`, {
     preserveScroll: true,
     onSuccess: () => (editing.value = false),
   });
 }
 
 function remove() {
-  form.delete(`/${usePage().props.path}/panels/${props.panel.id}`, {
+  form.delete(`${usePage().props.path}/panels/${props.panel.id}`, {
     preserveScroll: true,
   });
 }

--- a/resources/js/Components/Panel.vue
+++ b/resources/js/Components/Panel.vue
@@ -150,7 +150,7 @@ const params = new Proxy(new URLSearchParams(window.location.search), {
   get: (searchParams, prop) => searchParams.get(prop),
 });
 
-if (params.edit === parseInt(props.panel.id)) {
+if (parseInt(params.edit) === parseInt(props.panel.id)) {
   edit();
 }
 

--- a/resources/js/store.js
+++ b/resources/js/store.js
@@ -17,7 +17,7 @@ export const store = reactive({
   dashboards: {
     create() {
       router.post(
-        `/${usePage().props.path}/dashboards`,
+        `${usePage().props.path}/dashboards`,
         {},
         {
           preserveScroll: true,
@@ -28,7 +28,7 @@ export const store = reactive({
   panels: {
     create(dashboard) {
       router.post(
-        `/${usePage().props.path}/dashboards/${dashboard.id}/panels`,
+        `${usePage().props.path}/dashboards/${dashboard.id}/panels`,
         {},
         {
           preserveScroll: true,

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -12,7 +12,7 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request)
     {
         return array_merge(parent::share($request), [
-            'path' => config('chartello.path'),
+            'path' => url(config('chartello.path')),
         ]);
     }
 }


### PR DESCRIPTION
### Prior to this PR
We used relative paths across Chartello. This was sufficient for Laravel apps that were hosted at the root of a domain.
As reported in #7, apps that were in subdirectories did not work correctly with this setup. 

### In this PR
We make use of the `url()` helper, so that we account for the url of the host Laravel app. To make this work, we also had to update all JS files to work with absolute URLs. 